### PR TITLE
Prepend data option from the Webpack config to all the files

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ If you want to prepend Sass code before the actual entry file, you can set the d
 
 ```javascript
 {
-    loader: "sass-loader",
+    loader: "fast-sass-loader",
     options: {
         data: "$env: " + process.env.NODE_ENV + ";"
     }

--- a/README.md
+++ b/README.md
@@ -123,6 +123,26 @@ and you need install **node-sass** and **webpack** as peer dependencies.
 }
 ```
 
+## Options
+
+### includePaths:
+
+An array of paths that [node-sass](https://github.com/sass/node-sass) can look in to attempt to resolve your @import declarations. When using data, it is recommended that you use this.
+
+### data:
+If you want to prepend Sass code before the actual entry file, you can set the data option. In this case, the loader will not override the data option but just append the entry's content. This is especially useful when some of your Sass variables depend on the environment:
+
+```javascript
+{
+    loader: "sass-loader",
+    options: {
+        data: "$env: " + process.env.NODE_ENV + ";"
+    }
+}
+```
+
+Please note: Since you're injecting code, this will break the source mappings in your entry file. Often there's a simpler solution than this.
+
 ## Warning
 
 ### Mixing import `.scss` and`.sass` file is not allowed

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,8 @@ function getLoaderConfig (ctx) {
     basedir,
     includePaths,
     baseEntryDir: path.dirname(ctx.resourcePath),
-    root: options.root
+    root: options.root,
+    data: options.data
   }
 }
 
@@ -73,7 +74,10 @@ function * mergeSources (opts, entry, resolve, dependencies, level) {
   let includePaths = opts.includePaths
   let content = false
 
+  console.log('called-----------------------');
+
   if (opts.data) {
+    console.log('called---------------------1--');
     content = opts.data
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,10 @@ function * mergeSources (opts, entry, resolve, dependencies, level) {
   let includePaths = opts.includePaths
   let content = false
 
+  if (opts.data) {
+    content = opts.data
+  }
+
   if (typeof entry === 'object') {
     content = entry.content
     entry = entry.file

--- a/lib/index.js
+++ b/lib/index.js
@@ -82,7 +82,7 @@ function * mergeSources (opts, entry, resolve, dependencies, level) {
   }
 
   if (opts.data) {
-    content += opts.data
+    content = opts.data + '\n' + content
   }
 
   let entryDir = path.dirname(entry)

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,18 +74,15 @@ function * mergeSources (opts, entry, resolve, dependencies, level) {
   let includePaths = opts.includePaths
   let content = false
 
-  console.log('called-----------------------');
-
-  if (opts.data) {
-    console.log('called---------------------1--');
-    content = opts.data
-  }
-
   if (typeof entry === 'object') {
     content = entry.content
     entry = entry.file
   } else {
     content = yield fs.readFile(entry, 'utf8')
+  }
+
+  if (opts.data) {
+    content += opts.data
   }
 
   let entryDir = path.dirname(entry)

--- a/test/fixtures/withData/actual/index.scss
+++ b/test/fixtures/withData/actual/index.scss
@@ -1,0 +1,3 @@
+p {
+  color: $white;
+}

--- a/test/fixtures/withData/expect.css
+++ b/test/fixtures/withData/expect.css
@@ -1,0 +1,2 @@
+p {
+  color: #fff; }

--- a/test/fixtures/withData/extra/_variables.scss
+++ b/test/fixtures/withData/extra/_variables.scss
@@ -1,0 +1,1 @@
+$white: #fff;

--- a/test/fixtures/withData/webpack.config.js
+++ b/test/fixtures/withData/webpack.config.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const path = require('path')
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
+const loader = require.resolve('../../..')
+const cssLoader = require.resolve('css-loader')
+
+module.exports = {
+  context: path.join(__dirname),
+  entry: {
+    index: './actual/index.scss',
+  },
+  output: {
+    path: path.join(__dirname, '../../runtime/withData'),
+    filename: '[name].js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(scss|sass)$/,
+        use: ExtractTextPlugin.extract({
+          use: [
+            cssLoader,
+            {
+              loader: loader,
+              options: {
+                includePaths: [ path.join(__dirname, 'extra'), 'sass_modules'],
+                data: '@import "_variables.scss";'
+              }
+            }
+          ]
+        })
+      }
+    ]
+  },
+  plugins: [
+    new ExtractTextPlugin('[name].css')
+  ]
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -71,6 +71,30 @@ describe('test sass-loader', function () {
     })
   })
 
+  it('should load sass file with data option', function (done) {
+    const config = require('./fixtures/withData/webpack.config.js')
+    const compiler = webpack(config)
+
+    compiler.run((err, stats) => {
+      if (!handleError(err, stats, done)) {
+        return
+      }
+
+      try {
+        assert.equal(stats.errors, undefined)
+
+        let css = fs.readFileSync(path.join(__dirname, 'runtime/withData/index.css'), 'utf8')
+        let expect = fs.readFileSync(path.join(__dirname, 'fixtures/withData/expect.css'), 'utf8')
+
+        assert.equal(clearCRLF(css), clearCRLF(expect))
+        
+        done()
+      } catch (err) {
+        done(err)
+      }
+    })
+  })
+
   it('should compile without options', function (done) {
     const config = require('./fixtures/simple/webpack.config.js')
     const compiler = webpack(config)


### PR DESCRIPTION
Appends the data option from WebPack (if provided) which adds extra SASS code at the beginning of every file. This is useful if you want to define enviroment variables through the config. Example:

```javascript
{
  loader: 'fast-sass-loader',
  options: {
    data: "$env: " + process.env.NODE_ENV + ";"
  }
}
```

And it would create the following output for a SASS file:

```sass
$env: 'development';

.container {
  background-color: ($env == 'development' ? red : black);
}
```

Fixes #13 