### PR TITLE
Fix trailing semicolon issue in SASS files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ const loaderUtils = require('loader-utils')
 
 const EXT_PRECEDENCE = ['.scss', '.sass', '.css']
 const MATCH_URL_ALL = /url\(\s*(['"]?)([^ '"()]+)(\1)\s*\)/g
-const MATCH_IMPORTS = /@import\s+(['"])([^,;'"]+)(\1)(\s*,\s*(['"])([^,;'"]+)(\1))*\s*;/g
+const MATCH_IMPORTS = /@import\s+(['"])([^,;'"]+)(\1)(\s*,\s*(['"])([^,;'"]+)(\1))*\s*;?/g
 const MATCH_FILES = /(['"])([^,;'"]+)(\1)/g
 
 function getImportsToResolve (original, includePaths) {

--- a/test/fixtures/sass/expect.css
+++ b/test/fixtures/sass/expect.css
@@ -1,0 +1,5 @@
+.content {
+  display: flex; }
+
+.contentWrapper {
+  display: block; }

--- a/test/fixtures/sass/index.sass
+++ b/test/fixtures/sass/index.sass
@@ -1,0 +1,4 @@
+@import '_content.sass'
+
+.contentWrapper
+  display: block

--- a/test/fixtures/sass/sass_modules/_content.sass
+++ b/test/fixtures/sass/sass_modules/_content.sass
@@ -1,0 +1,2 @@
+.content
+  display: flex

--- a/test/fixtures/sass/webpack.config.js
+++ b/test/fixtures/sass/webpack.config.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const path = require('path')
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
+const loader = require.resolve('../../..')
+const cssLoader = require.resolve('css-loader')
+
+module.exports = {
+  context: path.join(__dirname),
+  entry: {
+    index: './index.sass'
+  },
+  output: {
+    path: path.join(__dirname, '../../runtime/sass'),
+    filename: '[name].js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(scss|sass)$/,
+        use: ExtractTextPlugin.extract({
+
+            use: [
+              cssLoader,
+              {
+                loader: loader,
+                options: {
+                includePaths: [ path.join(__dirname, 'extra'), 'sass_modules']
+                }
+              }
+
+            ]
+        })
+      },
+      {
+        test: /\.png$/,
+        loader: 'file-loader?name=[path][name].[ext]'
+      }
+    ]
+  },
+  plugins: [
+    new ExtractTextPlugin('[name].css')
+  ]
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -87,7 +87,7 @@ describe('test sass-loader', function () {
         let expect = fs.readFileSync(path.join(__dirname, 'fixtures/withData/expect.css'), 'utf8')
 
         assert.equal(clearCRLF(css), clearCRLF(expect))
-        
+
         done()
       } catch (err) {
         done(err)
@@ -101,6 +101,12 @@ describe('test sass-loader', function () {
 
   it('should resolve files with double extensions', function (done) {
     runSimpleTest(done, 'double-extensions')
+  })
+
+  context('when compiling SASS', function () {
+    it('supports import lines without trailing semicolons', function (done) {
+      runSimpleTest(done, 'sass');
+    });
   })
 })
 


### PR DESCRIPTION
For SASS, it's syntactically correct to have imports written without
trailing semicolon. However, the library fails to resolve files imported
this way, e.g.

```sass
@import 'content.sass'

.foo
  display: flex
```

Will fail to resolve `content.sass` even if it exists.

The issue is `MATCH_IMPORTS` regexp forces import lines to end with
semicolon.

This commit makes the regexp more permissive by allowing trailing
semicolons to be omitted in imports.