### PR TITLE
feat: add transformers opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,24 @@ If you want to prepend Sass code before the actual entry file, you can set the d
 
 Please note: Since you're injecting code, this will break the source mappings in your entry file. Often there's a simpler solution than this.
 
+### transformers:
+If you want to import files that aren't basic Sass or css files, you can use the transformers option. This option takes an array of transformer entries, each with a list of file extensions and a tranform function. If an imported file's extension matches one of the transformers' extensions, the file contents will be passed to the corresponding transform function. Your transform function should return a sass string that will be directly written into your compiled Sass file. This is especially useful if you use .json files to share your basic styles across platforms and you'd like to import your .json files directly into your Sass.
+```javascript
+{
+    loader: "fast-sass-loader",
+    options: {
+        transformers: [
+            {
+                extensions: [".json"],
+                transform: function(rawFile) {
+                    return jsonToSass(rawFile);
+                }
+            }
+        ]
+    }
+}
+```
+
 ## Warning
 
 ### Mixing import `.scss` and`.sass` file is not allowed

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ const MATCH_URL_ALL = /url\(\s*(['"]?)([^ '"()]+)(\1)\s*\)/g
 const MATCH_IMPORTS = /@import\s+(['"])([^,;'"]+)(\1)(\s*,\s*(['"])([^,;'"]+)(\1))*\s*;/g
 const MATCH_FILES = /(['"])([^,;'"]+)(\1)/g
 
-function getImportsToResolve (original, includePaths) {
+function getImportsToResolve (original, includePaths, transformers) {
   let extname = path.extname(original)
   let basename = path.basename(original, extname)
   let dirname = path.dirname(original)
@@ -23,14 +23,15 @@ function getImportsToResolve (original, includePaths) {
   let imports = []
   let names = [basename]
   let exts = [extname]
+  let extensionPrecedence = [].concat(EXT_PRECEDENCE, Object.keys(transformers))
 
   if (!extname) {
-    exts = EXT_PRECEDENCE
+    exts = extensionPrecedence
   }
-  if (extname && EXT_PRECEDENCE.indexOf(extname) === -1) {
+  if (extname && extensionPrecedence.indexOf(extname) === -1) {
     basename = path.basename(original)
     names = [basename]
-    exts = EXT_PRECEDENCE
+    exts = extensionPrecedence
   }
   if (basename[0] !== '_') {
     names.push('_' + basename)
@@ -51,10 +52,25 @@ function getImportsToResolve (original, includePaths) {
   return imports
 }
 
+function createTransformersMap (transformers) {
+  if (!transformers) {
+    return {}
+  }
+
+  // return map of extension strings to transformer functions
+  return transformers.reduce((extensionMap, transformer) => {
+    transformer.extensions.forEach((ext) => {
+      extensionMap[ext] = transformer.transform
+    })
+    return extensionMap
+  }, {})
+}
+
 function getLoaderConfig (ctx) {
   let options = loaderUtils.getOptions(ctx) || {}
   let includePaths = options.includePaths || []
   let basedir = ctx.options.context || process.cwd()
+  let transformers = createTransformersMap(options.transformers)
 
   // convert relative to absolute
   for (let i = 0; i < includePaths.length; i++) {
@@ -66,6 +82,7 @@ function getLoaderConfig (ctx) {
   return {
     basedir,
     includePaths,
+    transformers,
     baseEntryDir: path.dirname(ctx.resourcePath),
     root: options.root,
     data: options.data
@@ -77,6 +94,7 @@ function * mergeSources (opts, entry, resolve, dependencies, level) {
   dependencies = dependencies || []
 
   let includePaths = opts.includePaths
+  let transformers = opts.transformers
   let content = false
 
   if (typeof entry === 'object') {
@@ -84,6 +102,12 @@ function * mergeSources (opts, entry, resolve, dependencies, level) {
     entry = entry.file
   } else {
     content = yield fs.readFile(entry, 'utf8')
+  }
+
+  let ext = path.extname(entry)
+
+  if (transformers[ext]) {
+    content = transformers[ext](content)
   }
 
   if (opts.data) {
@@ -151,7 +175,7 @@ function * mergeSources (opts, entry, resolve, dependencies, level) {
         throw err
       }
 
-      let imports = getImportsToResolve(originalImport, includePaths)
+      let imports = getImportsToResolve(originalImport, includePaths, transformers)
       let resolvedImport
 
       for (let i = 0; i < imports.length; i++) {

--- a/test/fixtures/withTransformer/actual/colors.color
+++ b/test/fixtures/withTransformer/actual/colors.color
@@ -1,0 +1,1 @@
+white: #fff

--- a/test/fixtures/withTransformer/actual/index.scss
+++ b/test/fixtures/withTransformer/actual/index.scss
@@ -1,0 +1,5 @@
+@import './colors.color';
+
+p {
+  color: $white;
+}

--- a/test/fixtures/withTransformer/expect.css
+++ b/test/fixtures/withTransformer/expect.css
@@ -1,0 +1,2 @@
+p {
+  color: #fff; }

--- a/test/fixtures/withTransformer/webpack.config.js
+++ b/test/fixtures/withTransformer/webpack.config.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const path = require('path')
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
+const loader = require.resolve('../../..')
+const cssLoader = require.resolve('css-loader')
+
+module.exports = {
+  context: path.join(__dirname),
+  entry: {
+    index: './actual/index.scss',
+  },
+  output: {
+    path: path.join(__dirname, '../../runtime/withTransformer'),
+    filename: '[name].js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(scss|sass)$/,
+        use: ExtractTextPlugin.extract({
+          use: [
+            cssLoader,
+            {
+              loader: loader,
+              options: {
+                transformers: [{
+                  extensions: ['.color'],
+                  transform: function(rawFile) {
+                    return '$' + rawFile + ';'
+                  }
+                }],
+              }
+            }
+          ]
+        })
+      }
+    ]
+  },
+  plugins: [
+    new ExtractTextPlugin('[name].css')
+  ]
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -102,6 +102,10 @@ describe('test sass-loader', function () {
   it('should resolve files with double extensions', function (done) {
     runSimpleTest(done, 'double-extensions')
   })
+
+  it('should be able to import non sass files with a passed transformer', function(done) {
+    runSimpleTest(done, 'withTransformer')
+  })
 })
 
 function runSimpleTest (done, fixtureName) {


### PR DESCRIPTION
Greetings!

I wrote these changes to specifically address this [issue](https://github.com/yibn2008/fast-sass-loader/issues/22) that I opened a little while back. To recap, we use .json files to share our most basic styles across platforms like web, android and ios. It would be really neat if we could use fast-sass-loader and import them directly in our scss files. 

This change allows users to pass extensions and corresponding transform functions to format any type of file into something that is sass compatible. I added tests, updated the readme and tried to stick with the style of the rest of the file as much as possible. 

Let me know what you think! Thanks!