### PR TITLE
Add Webpack 4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![Build Status](https://travis-ci.org/yibn2008/fast-sass-loader.svg?branch=master)](https://travis-ci.org/yibn2008/fast-sass-loader)
 [![Coverage Status](https://coveralls.io/repos/github/yibn2008/fast-sass-loader/badge.svg)](https://coveralls.io/github/yibn2008/fast-sass-loader)
 
-High performance sass loader for webpack 1/2/3.
+High performance sass loader for webpack 1/2/3/4.
 
 Features:
 
 - 5~10 times faster than `sass-loader` in large sass project
-- support sass file dedupe, never worry about `@ import` same file in different place
+- support sass file dedupe, never worry about `@import` same file in different place
 - support url resolve, never worry about the problem with `url(...)` (see https://github.com/webpack-contrib/sass-loader#problems-with-url)
 
 fast sass loader for webpack. 5~10 times faster than **sass-loader**, and support url resolve.
@@ -81,7 +81,7 @@ and you need install **node-sass** and **webpack** as peer dependencies.
 
 ## Configration
 
-### webpack 2:
+### webpack 2, 3 and 4:
 
 ```
 {

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ function createTransformersMap (transformers) {
 function getLoaderConfig (ctx) {
   const options = loaderUtils.getOptions(ctx) || {}
   const includePaths = options.includePaths || []
-  const basedir = options.context || process.cwd()
+  const basedir = ctx.rootContext || options.context || ctx.options.context || process.cwd()
   const transformers = createTransformersMap(options.transformers)
 
   // convert relative to absolute

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,10 +67,10 @@ function createTransformersMap (transformers) {
 }
 
 function getLoaderConfig (ctx) {
-  let options = loaderUtils.getOptions(ctx) || {}
-  let includePaths = options.includePaths || []
-  let basedir = ctx.options.context || process.cwd()
-  let transformers = createTransformersMap(options.transformers)
+  const options = loaderUtils.getOptions(ctx) || {}
+  const includePaths = options.includePaths || []
+  const basedir = options.context || process.cwd()
+  const transformers = createTransformersMap(options.transformers)
 
   // convert relative to absolute
   for (let i = 0; i < includePaths.length; i++) {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "node-sass": "4.x || 3.x",
-    "webpack": "1.x || 2.x || 3.x"
+    "webpack": "1.x || 2.x || 3.x || 4.x"
   },
   "devDependencies": {
     "coveralls": "^2.12.0",
@@ -64,7 +64,7 @@
     "rimraf": "^2.6.1",
     "sass-loader": "^6.0.3",
     "standard": "*",
-    "webpack": "1.x || 2.x || 3.x"
+    "webpack": "1.x || 2.x || 3.x || 4.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Previously, we were using `context.options`, which was deprecated in Webpack 3 and removed in Webpack 4 (https://medium.com/webpack/webpack-4-migration-guide-for-plugins-loaders-20a79b927202).

This shouldn't break any previous versions because we still use `loader-utils` to get the options.

Fixes #28 