### PR TITLE
Add outputStyle to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm install fast-sass-loader --save-dev
 
 and you need install **node-sass** and **webpack** as peer dependencies.
 
-## Configration
+## Configuration
 
 ### webpack 2, 3 and 4:
 
@@ -129,6 +129,9 @@ If you want to import files that aren't basic Sass or css files, you can use the
     }
 }
 ```
+
+### outputStyle:
+The outputStyle option is passed to the render method of node-sass. See [node-sass OutputStyle](https://github.com/sass/node-sass/blob/master/README.md#outputstyle). This can be used to create smaller css files if set to "compressed".
 
 ## Warning
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,6 +90,7 @@ function getLoaderConfig (ctx) {
     includePaths,
     transformers,
     baseEntryDir: path.dirname(ctx.resourcePath),
+    outputStyle: options.outputStyle,
     root: options.root,
     data: options.data
   }
@@ -278,6 +279,7 @@ module.exports = function (content) {
         let result = yield new Promise((resolve, reject) => {
           sass.render({
             indentedSyntax: entry.endsWith('.sass'),
+            outputStyle: options.outputStyle,
             file: entry,
             data: merged
           }, (err, result) => {

--- a/test/fixtures/pass-output-style/expect.css
+++ b/test/fixtures/pass-output-style/expect.css
@@ -1,0 +1,1 @@
+.foobar{color:#FFF;background-image:url(_/normal/actual/img/logo.png)}header{color:#AAA}

--- a/test/fixtures/pass-output-style/foobar.scss
+++ b/test/fixtures/pass-output-style/foobar.scss
@@ -1,0 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+* This is a long explanatory usage comment that should not be put into the Copyright (c) 2019 Bentley Systems, Incorporated. All rights reserved.
+*--------------------------------------------------------------------------------------------*/
+.foobar {
+  color: #FFF;
+  background-image: url("../normal/actual/img/logo.png");
+}

--- a/test/fixtures/pass-output-style/foobar.scss
+++ b/test/fixtures/pass-output-style/foobar.scss
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
-* This is a long explanatory usage comment that should not be put into the Copyright (c) 2019 Bentley Systems, Incorporated. All rights reserved.
+* This is a long explanatory usage comment that should not be put into the output .css file
 *--------------------------------------------------------------------------------------------*/
 .foobar {
   color: #FFF;

--- a/test/fixtures/pass-output-style/index.scss
+++ b/test/fixtures/pass-output-style/index.scss
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+* This is a long explanatory usage comment that should not be put into the Copyright (c) 2019 Bentley Systems, Incorporated. All rights reserved.
+*--------------------------------------------------------------------------------------------*/
+@import "foobar.scss";
+
+header {
+  color: #AAA;
+}

--- a/test/fixtures/pass-output-style/index.scss
+++ b/test/fixtures/pass-output-style/index.scss
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
-* This is a long explanatory usage comment that should not be put into the Copyright (c) 2019 Bentley Systems, Incorporated. All rights reserved.
+* This is a long explanatory usage comment that should not be put into the output .css file
 *--------------------------------------------------------------------------------------------*/
 @import "foobar.scss";
 

--- a/test/fixtures/pass-output-style/webpack.config.js
+++ b/test/fixtures/pass-output-style/webpack.config.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const path = require('path')
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
+const loader = require.resolve('../../..')
+const cssLoader = require.resolve('css-loader')
+
+module.exports = {
+  context: path.join(__dirname),
+  entry: {
+    index: './index.scss'
+  },
+  output: {
+    path: path.join(__dirname, '../../runtime/pass-output-style'),
+    filename: '[name].js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(scss|sass)$/,
+        use: ExtractTextPlugin.extract({
+          use: [
+            cssLoader,
+            {
+              loader: loader,
+              options: {
+                outputStyle: 'compressed'
+              }
+            }
+          ]
+        }),
+      },
+      {
+        test: /\.png$/,
+        loader: 'file-loader?name=[path][name].[ext]'
+      }
+    ]
+  },
+  plugins: [
+    new ExtractTextPlugin('[name].css')
+  ]
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -143,7 +143,12 @@ describe('test sass-loader', function () {
     runSimpleTest(done, 'data-import-issue')
   })
 
+  it('should pass options to sass.render (#53)', function (done) {
+    runSimpleTest(done, 'pass-output-style')
+  })
+
   it('should be able to resolve @import "bulma" (#40)', function (done) {
     runSimpleTest(done, 'bulma-issue')
   })
+
 })


### PR DESCRIPTION
Add outputStyle to options, which is passed to the render method of node-sass. If outputStyle
is "compressed", a smaller .css file is created.