### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "file-loader": "^0.9.0",
     "husky": "*",
     "mocha": "^3.2.0",
-    "node-sass": "^5.0.0",
     "npm-ensure": "^1.1.0",
     "nyc": "*",
     "prettier": "^1.19.1",


### PR DESCRIPTION
You do not need to install node-sass to projects where this lib is used if they don't need it. If they need - they'll add it in their package.json files.