### PR TITLE
Rough fix of @use rule usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/yibn2008/fast-sass-loader.svg?branch=master)](https://travis-ci.org/yibn2008/fast-sass-loader)
 [![Coverage Status](https://coveralls.io/repos/github/yibn2008/fast-sass-loader/badge.svg)](https://coveralls.io/github/yibn2008/fast-sass-loader)
 
-Blazingly fast sass loader for webpack.
+Blazingly fast sass loader for webpack. Version with use hoisting.
 
 *Tips: using with [fast-css-loader](https://github.com/yibn2008/fast-css-loader) you will get more than 10 times css build performance*
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/yibn2008/fast-sass-loader.svg?branch=master)](https://travis-ci.org/yibn2008/fast-sass-loader)
 [![Coverage Status](https://coveralls.io/repos/github/yibn2008/fast-sass-loader/badge.svg)](https://coveralls.io/github/yibn2008/fast-sass-loader)
 
-Blazingly fast sass loader for webpack. Version with use hoisting.
+Blazingly fast sass loader for webpack.
 
 *Tips: using with [fast-css-loader](https://github.com/yibn2008/fast-css-loader) you will get more than 10 times css build performance*
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,7 +106,7 @@ function getLoaderConfig (ctx) {
 function hoistUseRule (content) {
   const list = []
 
-  const cleared = content.replace(/@use ['"][^'"]*['"];/g, (match) => {
+  const cleared = content.replace(/@use [^;];/g, (match) => {
     if (!list.includes(match)) {
       list.push(match)
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,6 +103,20 @@ function getLoaderConfig (ctx) {
   }
 }
 
+function hoistUse (content) {
+  const list = [];
+
+  const cleared = content.replace(/@use "(sass:math|sass:list)";/g, (match) => {
+    if (!list.includes(match)) {
+      list.push(match)
+    }
+
+    return '';
+  })
+
+  return list.join('\n') + cleared;
+}
+
 function * mergeSources (opts, entry, resolve, dependencies, level) {
   level = level || 0
   dependencies = dependencies || []
@@ -274,7 +288,7 @@ module.exports = function (content) {
         content = options.data + '\n' + content
       }
 
-      const merged = yield mergeSources(
+      const merged = hoistUse(yield mergeSources(
         options,
         {
           file: entry,
@@ -282,7 +296,7 @@ module.exports = function (content) {
         },
         resolver(ctx),
         dependencies
-      )
+      ))
 
       dependencies.forEach(file => {
         ctx.dependency(file)

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,18 +103,18 @@ function getLoaderConfig (ctx) {
   }
 }
 
-function hoistUse (content) {
-  const list = [];
+function hoistUseRule (content) {
+  const list = []
 
-  const cleared = content.replace(/@use "(sass:math|sass:list)";/g, (match) => {
+  const cleared = content.replace(/@use ['"][^'"]*['"];/g, (match) => {
     if (!list.includes(match)) {
       list.push(match)
     }
 
-    return '';
+    return ''
   })
 
-  return list.join('\n') + cleared;
+  return list.join('\n') + cleared
 }
 
 function * mergeSources (opts, entry, resolve, dependencies, level) {
@@ -288,7 +288,7 @@ module.exports = function (content) {
         content = options.data + '\n' + content
       }
 
-      const merged = hoistUse(yield mergeSources(
+      const merged = hoistUseRule(yield mergeSources(
         options,
         {
           file: entry,

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,7 +106,7 @@ function getLoaderConfig (ctx) {
 function hoistUseRule (content) {
   const list = []
 
-  const cleared = content.replace(/@use [^;];/g, (match) => {
+  const cleared = content.replace(/@use [^;]*;/g, (match) => {
     if (!list.includes(match)) {
       list.push(match)
     }

--- a/test/fixtures/use-rule/expect.css
+++ b/test/fixtures/use-rule/expect.css
@@ -1,0 +1,11 @@
+header {
+  background: #ccc;
+}
+
+header {
+  width: 1px;
+}
+
+header {
+  height: 1px;
+}

--- a/test/fixtures/use-rule/index.scss
+++ b/test/fixtures/use-rule/index.scss
@@ -1,0 +1,3 @@
+@import "without-use.scss";
+@import "with-use.scss";
+@import "second-with-use.scss";

--- a/test/fixtures/use-rule/second-with-use.scss
+++ b/test/fixtures/use-rule/second-with-use.scss
@@ -1,0 +1,5 @@
+@use "sass:math";
+
+header {
+  height: math.div(6px, 6);
+}

--- a/test/fixtures/use-rule/webpack.config.js
+++ b/test/fixtures/use-rule/webpack.config.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const path = require('path')
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
+const loader = require.resolve('../../..')
+const cssLoader = require.resolve('css-loader')
+
+module.exports = {
+  context: path.join(__dirname),
+  entry: {
+    index: './index.scss'
+  },
+  output: {
+    path: path.join(__dirname, '../../runtime/use-rule'),
+    filename: '[name].js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(scss|sass)$/,
+        use: ExtractTextPlugin.extract({
+          use: [
+            cssLoader,
+            loader
+          ]
+        })
+      },
+      {
+        test: /\.png$/,
+        loader: 'file-loader?name=[path][name].[ext]'
+      }
+    ]
+  },
+  plugins: [
+    new ExtractTextPlugin('[name].css')
+  ]
+}

--- a/test/fixtures/use-rule/with-use.scss
+++ b/test/fixtures/use-rule/with-use.scss
@@ -1,0 +1,5 @@
+@use "sass:math";
+
+header {
+  width: math.div(5px, 5);
+}

--- a/test/fixtures/use-rule/without-use.scss
+++ b/test/fixtures/use-rule/without-use.scss
@@ -1,0 +1,3 @@
+header {
+  background: #ccc;
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -148,6 +148,11 @@ describe('test sass-loader', function() {
     runSimpleTest(done, 'data-import-issue')
   })
 
+
+  it('should be able to hoist @use rule usage in merged content', function(done) {
+    runSimpleTest(done, 'use-rule')
+  })
+
   it('should pass options to sass.render (#53)', function(done) {
     runSimpleTest(done, 'pass-output-style')
   })


### PR DESCRIPTION
Allow to declare imports with `@use` rule in every file deduping its usage in merged file – hoisting it to the beginning. This fixes problem with this rule on my end. `dart-sass` warns about literal slash usage in favour of `math.div` and `list.slash` and I really wanted to use fast-sass-loader with it.

If you have better idea how to handle this – feel free to give me feedback.